### PR TITLE
Fixed TypeError thrown by packages-available

### DIFF
--- a/wapt.py
+++ b/wapt.py
@@ -180,7 +180,7 @@ def main():
                     if 'revision' in pkg_:
                         rev = pkg_['revision']
                     if pkg in packages:
-                        if rev > packages[pkg]:
+                        if rev > packages[pkg][0]:
                             packages[pkg] = (rev, group)
                     else:
                         packages[pkg] = (rev, group)


### PR DESCRIPTION
```
wapt packages-available 3.8.1
```

```
Traceback (most recent call last):
  File "/usr/bin/wapt", line 211, in <module>
    main()
  File "/usr/bin/wapt", line 183, in main
    if rev > packages[pkg]:
TypeError: '>' not supported between instances of 'int' and 'tuple'
```